### PR TITLE
Deep dev reply

### DIFF
--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-tosca_simple_yaml_1_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-tosca_simple_yaml_1_0.yml.vm
@@ -160,7 +160,7 @@ ${utils.formatArtifact($operationEntry.value.implementationArtifact, 10)}
 #else
           ${operationEntry.key}:
 #if($utils.mapIsNotEmptyAndContainsNotnullValues($operationEntry.value.inputParameters))
-            input:$propertyUtils.formatProperties(7, $operationEntry.value.inputParameters)
+            inputs:$propertyUtils.formatProperties(7, $operationEntry.value.inputParameters)
 #end
             implementation:
 ${utils.formatArtifact($operationEntry.value.implementationArtifact, 7)}

--- a/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-tosca_simple_yaml_1_0.yml.vm
+++ b/alien4cloud-core/src/main/resources/org/alien4cloud/tosca/exporter/topology-tosca_simple_yaml_1_0.yml.vm
@@ -8,10 +8,9 @@
 ## BEGINNING OF DOCUMENT
 tosca_definitions_version: tosca_simple_yaml_1_0
 
-metadata:
-  template_name: ${template_name}
-  template_version: ${template_version}
-  template_author: ${template_author}
+template_name: ${template_name}
+template_version: ${template_version}
+template_author: ${template_author}
 
 description: ${utils.renderDescription(${template_description}, "")}
 #if($utils.collectionIsNotEmpty($topology.dependencies))

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaPropertySerializerUtils.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaPropertySerializerUtils.java
@@ -89,7 +89,7 @@ public class ToscaPropertySerializerUtils {
         if (value.getParameters().size() == 1) {
             buffer.append("{ ").append(value.getFunction()).append(": ").append(value.getParameters().get(0)).append(" }");
         } else {
-            buffer.append("{ ").append(value.getFunction()).append(": [").append(ToscaSerializerUtils.getCsvToString(value.getParameters())).append("] }");
+            buffer.append("{ ").append(value.getFunction()).append(": [ ").append(ToscaSerializerUtils.getCsvToString(value.getParameters(), true)).append(" ] }");
         }
         return buffer.toString();
     }

--- a/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaPropertySerializerUtils.java
+++ b/alien4cloud-tosca/src/main/java/alien4cloud/tosca/serializer/ToscaPropertySerializerUtils.java
@@ -131,6 +131,9 @@ public class ToscaPropertySerializerUtils {
     }
 
     private static String formatListValue(int indentLevel, List<Object> value) {
+        if (value.isEmpty()) {
+            return "[]";
+        }
         indentLevel++;
         StringBuilder buffer = new StringBuilder();
         for (Object element : value) {


### PR DESCRIPTION
- Fix serialization typo for operation inputs
  - It's `inputs`, not `input`
- Normative 1.0 name, version, and author serialization
- Serialize function parameters between quotes when needed
  - Values with colons like `http://` are not put between colons, e.g. 
`concat: [ https://, { get_attribute: [ master_server, public_address, 0 ] }, :443 ] }` 
instead of 
`concat: [ "https://", { get_attribute: [ master_server, public_address, 0 ] }, ":443" ] }`
- Fix serialization of empty ListPropertyValues
  - empy property list are not properly serialized, e.g. `wn_ips: ` insteat of `wn_ips: []`